### PR TITLE
docs: fix typos

### DIFF
--- a/custom/quickstart.md
+++ b/custom/quickstart.md
@@ -232,4 +232,4 @@ Often you may want your API to automatically start a server or a connection when
 
 For example if your API involves a database system, you will probably want to make sure that your DB automatically starts up when Pinokio starts, so the endpoint will be available when you make API requests immediately after.
 
-In these cases, you can use the [self driving scripts](/tutorial/autostart) to automatically launch whatever services you need, automatically.
+In these cases, you can use the [self driving scripts](/tutorial/autostart) to automatically launch whatever services you need.

--- a/custom/what.md
+++ b/custom/what.md
@@ -4,7 +4,7 @@
 
 In Pinokio, APIs are local JavaScript classes that behave like remote servers.
 
-It's easy to understand when we compare it to traditional APIs.
+It's easy to understand when we compare them to traditional APIs.
 
 ## Traditional API vs. Pinokio API
 
@@ -46,7 +46,7 @@ Here's an example Pinokio request:
 
 Here's how it works:
 
-1. First download the JavaScript module at `https://github.com/cocktailpeanut/sum.git` (**NOTE: the URI is used to DOWNLOAD the entire repository, not to make a reuqest to it**)
+1. First download the JavaScript module at `https://github.com/cocktailpeanut/sum.git` (**NOTE: the URI is used to DOWNLOAD the entire repository, not to make a request to it**)
 2. Resolve the endpoint by importing the JavaScript module at `api.js`
 3. Look up the exported `sum()` inside the `api.js` file
 4. Pass in the `params` to the resolved `sum()` method.


### PR DESCRIPTION
Was browsing through the documentation and found a couple of minor typos.